### PR TITLE
Normalise History to “IndieAuth.com”

### DIFF
--- a/views/history.erb
+++ b/views/history.erb
@@ -4,12 +4,12 @@
 
   <div class="section narrow large h-entry">
 
-      <h2 id="history" class="p-name">The History of IndieAuth</h2>
+      <h2 id="history" class="p-name">The History of IndieAuth.com</h2>
 
       <p>By <a href="http://aaronparecki.com/" rel="author" class="p-author h-card">Aaron Parecki</a></p>
 
       <div class="e-content">
-        <p>IndieAuth is an implementation of <a href="http://microformats.org/wiki/RelMeAuth">RelMeAuth</a>, originally <a href="http://tantek.com/2010/032/t5/modest-proposal-authentication-oauth-twitter-rel-me">proposed by Tantek Çelik</a> in February 2010. The original algorithm was described <a href="http://tantek.com/2010/032/t6/relmeauth-oauth-rel-me-auto-fallback-authentication">in a short text update</a> on Tantek's website. Later that evening, Jeff Lindsay and Paul Tarjan implemented RelMeAuth in an open source Python library at Hacker Dojo and <a href="http://krijnhoetmer.nl/irc-logs/microformats/20100203">discussed/tested it in IRC</a>. Tantek later launched a RelMeAuth prototype on his domain, which you can try out at <a href="http://tantek.com/relmeauth/">tantek.com/relmeauth</a>.</p>
+        <p>IndieAuth.com is an implementation of <a href="http://microformats.org/wiki/RelMeAuth">RelMeAuth</a>, originally <a href="http://tantek.com/2010/032/t5/modest-proposal-authentication-oauth-twitter-rel-me">proposed by Tantek Çelik</a> in February 2010. The original algorithm was described <a href="http://tantek.com/2010/032/t6/relmeauth-oauth-rel-me-auto-fallback-authentication">in a short text update</a> on Tantek's website. Later that evening, Jeff Lindsay and Paul Tarjan implemented RelMeAuth in an open source Python library at Hacker Dojo and <a href="http://krijnhoetmer.nl/irc-logs/microformats/20100203">discussed/tested it in IRC</a>. Tantek later launched a RelMeAuth prototype on his domain, which you can try out at <a href="http://tantek.com/relmeauth/">tantek.com/relmeauth</a>.</p>
 
         <p>In 2011, we held the first <a href="https://indieweb.org/2011">IndieWebCamp</a> in Portland. The registration process involved setting up OpenID on your own domain (or delegating your domain to an OpenID provider), and signing in to the IndieWebCamp Wiki and adding yourself to the <a href="https://indieweb.org/2011/Guest_List">guest list</a>. Most people were able to successfully complete this <a href="https://indieweb.org/How_to_set_up_OpenID_on_your_own_domain">intentional barrier to entry</a>, but there were still parts that were cumbersome.</p>
 


### PR DESCRIPTION
The History page refers to the birth of “IndieAuth.com” and how people can rely on “IndieAuth.com to do the legwork” around RelMeAuth. So lets use the .com-suffix consistently throughout.