### PR TITLE
Give a URL as an example for this input

### DIFF
--- a/views/sign_in.erb
+++ b/views/sign_in.erb
@@ -5,7 +5,7 @@
       <form action="<%= SiteConfig.root %>/auth" method="get" class="well" style="margin: 20px 0;">
         <div class="form-group">
           <label for="indie_auth_url">Your Website:</label>
-          <input id="indie_auth_url" type="url" name="me" class="form-control" placeholder="yourdomain.com" />
+          <input id="indie_auth_url" type="url" name="me" class="form-control" placeholder="https://yourdomain.com/" />
         </div>
         <button type="submit" class="btn btn-primary">Sign In</button>
         <input type="hidden" name="redirect_uri" value="<%= params['redirect_uri'] ? params['redirect_uri'] : "#{SiteConfig.root}/success" %>" />


### PR DESCRIPTION
This 'Sign in' form, at least in Chrome, is picky about input - trying macwright.org is caught by form validation, but adding https:// works. There's the other route - using a text form instead of a URL form. But if the goal is to use a URL form, the example should be a URL so that folks don't get tripped up by trying to use a domain.