### PR TITLE
gpg: clearsigning command

### DIFF
--- a/views/pgp.erb
+++ b/views/pgp.erb
@@ -39,7 +39,7 @@
 
         <h4>GnuPG</h4>
         <p>If you use gpg from the command line you can sign a text message with the following command.</p>
-        <pre>$ echo '(challenge text from indieauth.com)' | gpg --clearsign --armor </pre>
+        <pre>$ echo '(challenge text from indieauth.com)' | gpg --clearsign </pre>
 
         <h4>Keybase.io</h4>
         <p>If you are using <a href="https://keybase.io">Keybase.io</a> you can sign it on the command line with <code>keybase pgp sign -m '(challenge text from indieauth.com)'</code></p>


### PR DESCRIPTION
* Removed "--armor" as it is unnecessary.  All clearsigning is
  armored, it's impossible for it to be any other way.  Only detached
  and normal (default) signatures enable the binary format output.