### PR TITLE
Add gitlab.com login

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ gem 'omniauth', ">=1.5.0"
 gem 'omniauth-facebook'
 gem 'omniauth-flickr'
 gem 'omniauth-github', ">=1.3.0"
+gem 'omniauth-gitlab'
 gem 'omniauth-google-oauth2'
 gem 'omniauth-openid'
 gem 'omniauth-eventbrite'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,6 +84,9 @@ GEM
     omniauth-github (1.3.0)
       omniauth (~> 1.5)
       omniauth-oauth2 (>= 1.4.0, < 2.0)
+    omniauth-gitlab (1.0.3)
+      omniauth (~> 1.0)
+      omniauth-oauth2 (~> 1.0)
     omniauth-google-oauth2 (0.5.2)
       jwt (~> 1.5)
       multi_json (~> 1.3)
@@ -188,6 +191,7 @@ DEPENDENCIES
   omniauth-facebook
   omniauth-flickr
   omniauth-github (>= 1.3.0)
+  omniauth-gitlab
   omniauth-google-oauth2
   omniauth-openid
   puma

--- a/config.yml.template
+++ b/config.yml.template
@@ -23,7 +23,10 @@ development:
       client_secret: 
     github:
       client_id: 
-      client_secret: 
+      client_secret:
+    gitlab:
+      client_id:
+      client_secret:
     google_oauth2:
       client_id: 
       client_secret: 

--- a/controllers/auth-web.rb
+++ b/controllers/auth-web.rb
@@ -636,7 +636,7 @@ class Controller < Sinatra::Base
         actual_username = match[1]
       end
     else
-      actual_username = auth['info']['nickname']
+      actual_username = auth['info']['nickname'] || auth['info']['username']
     end
 
     puts "Auth complete!"

--- a/lib/omniauth.rb
+++ b/lib/omniauth.rb
@@ -15,6 +15,8 @@ module OmniAuth
       exists = class_exists?('Foursquare')
     when 'github'
       exists = class_exists?('GitHub')
+    when 'gitlab'
+      exists = class_exists?('GitLab')
     when 'google_oauth2'
       exists = class_exists?('GoogleOauth2')
     else

--- a/models/provider.rb
+++ b/models/provider.rb
@@ -28,6 +28,7 @@ class Provider
       #'eventbrite' => 'https?:\/\/(.+)\.eventbrite\.com',
       #'flickr' => 'https?:\/\/(?:www\.)?flickr\.com\/(?:people\/)?([^\/]+)',
       'github' => 'https?:\/\/(?:www\.)?github\.com\/([^\/]+)',
+      'gitlab' => 'https?:\/\/(?:www\.)?gitlab\.com\/([^\/]+)',
       #'google_oauth2' => 'https?:\/\/(?:www\.)?(?:profiles\.|plus\.|)google\.com\/([^\/]+)',
       #'lastfm' => 'https?:\/\/(?:www\.)?last\.fm\/user\/(.+)',
       'twitter' => 'https?:\/\/(?:www\.)?twitter\.com\/([^\/]+)'


### PR DESCRIPTION
Hello 👋 

This PR adds GitLab.com login support.

A new application can be generated from https://gitlab.com/-/profile/applications, it requires to be set as "confidential" and the "api" scope.


<img width="722" alt="oauth app screenshot" src="https://user-images.githubusercontent.com/78752/99880799-e43bed00-2c15-11eb-869d-96362f5f0184.png">
