### PR TITLE
Change GitLab OAuth scope to read_user

### DIFF
--- a/controllers/auth-web.rb
+++ b/controllers/auth-web.rb
@@ -634,7 +634,7 @@ class Controller < Sinatra::Base
     profile = Profile.find :me => session[:attempted_uri], :profile => session[:attempted_profile]
     attempted_username = session[:attempted_username]
     actual_username = ''
-    if profile['provider'] == 'google_oauth2'
+    if profile && profile['provider'] == 'google_oauth2'
       authed_url = auth['extra']['raw_info']['profile']
       if authed_url && (match=authed_url.match(Regexp.new Provider.regexes[profile['provider']]))
         actual_username = match[1]

--- a/environment.rb
+++ b/environment.rb
@@ -65,6 +65,8 @@ class Controller < Sinatra::Base
           provider code.to_sym, p['client_id'], p['client_secret'], {access_type: 'online', approval_prompt: '', scope: 'profile,userinfo.profile,plus.me'} if p['client_id']
         when 'github'
           provider code.to_sym, p['client_id'], p['client_secret'], {client_options: {redirect_uri: SiteConfig.root+'/auth/github/callback'}}
+        when 'gitlab'
+          provider code.to_sym, p['client_id'], p['client_secret'], {scope: 'read_user'} if p['client_id']
         else
           provider code.to_sym, p['client_id'], p['client_secret'] if p['client_id']
         end


### PR DESCRIPTION
Following the principle of least privilege, this PR drops the requested scope to `read_user`.

To avoid service disruption I suggest you to add `read_user` scope to the GitLab application before the deployment, and remove `api` scope only after a successful deployment.