### PR TITLE
Fixes Omniauth link

### DIFF
--- a/views/faq.erb
+++ b/views/faq.erb
@@ -31,7 +31,7 @@
         <ul>
           <li>Ensure your users have a way to enter their website address in the "profile" section of your website.</li>
           <li>When displaying the HTML rendering of a user's page, ensure the <a href="http://microformats.org/wiki/rel-me">rel="me"</a> attribute is set on the link.</li>
-          <li>Write an <a href="http://www.omniauth.org/">Omniauth</a> plugin to handle authenticating with your API, and submit it to the <a href="https://github.com/intridea/omniauth/wiki/List-of-Strategies">List of Omniauth Strategies</a> page.</li>
+          <li>Write an <a href="https://github.com/omniauth/omniauth">Omniauth</a> plugin to handle authenticating with your API, and submit it to the <a href="https://github.com/intridea/omniauth/wiki/List-of-Strategies">List of Omniauth Strategies</a> page.</li>
           <li>Integrate the new provider into the <a href="https://github.com/aaronpk/IndieAuth">IndieAuth.com source code</a>, or just <a href="https://github.com/aaronpk/IndieAuth/issues/new">open an issue</a> with your request.</li>
         </ul>
       </p>


### PR DESCRIPTION
The link to `omniauth.org` is broken - replace with link to GitHub